### PR TITLE
db: 接続数上限を外す

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -328,8 +328,8 @@ func main() {
 	}
 	defer dbx.Close()
 
-	dbx.SetMaxOpenConns(10)
-	dbx.SetMaxIdleConns(10)
+	//dbx.SetMaxOpenConns(10)
+	//dbx.SetMaxIdleConns(10)
 	dbx.SetConnMaxLifetime(time.Minute * 2)
 
 	log.SetFlags(log.Lmicroseconds | log.Lshortfile)


### PR DESCRIPTION
デッドロックしてるっぽい。
どっかで接続を無駄に使ってるところが残ってるらしい。