### PR TITLE
campaign: 1

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -328,7 +328,7 @@ func main() {
 	}
 	defer dbx.Close()
 
-	dbx.SetMaxOpenConns(200)
+	dbx.SetMaxOpenConns(100)
 	dbx.SetMaxIdleConns(200)
 	dbx.SetConnMaxLifetime(time.Minute * 2)
 

--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -328,8 +328,8 @@ func main() {
 	}
 	defer dbx.Close()
 
-	//dbx.SetMaxOpenConns(10)
-	//dbx.SetMaxIdleConns(10)
+	dbx.SetMaxOpenConns(200)
+	dbx.SetMaxIdleConns(200)
 	dbx.SetConnMaxLifetime(time.Minute * 2)
 
 	log.SetFlags(log.Lmicroseconds | log.Lshortfile)
@@ -559,7 +559,7 @@ func postInitialize(w http.ResponseWriter, r *http.Request) {
 
 	res := resInitialize{
 		// キャンペーン実施時には還元率の設定を返す。詳しくはマニュアルを参照のこと。
-		Campaign: 0,
+		Campaign: 1,
 		// 実装言語を返す
 		Language: "Go",
 	}


### PR DESCRIPTION
too many connections が出るのでコネクション数を制限する。
トランザクション中にAPI呼び出ししているので数は多め。